### PR TITLE
Fix module startup

### DIFF
--- a/jupyter_mcp_server/__main__.py
+++ b/jupyter_mcp_server/__main__.py
@@ -2,9 +2,8 @@
 #
 # BSD 3-Clause License
 
-from jupyter_mcp_server.server import start
-
+from jupyter_mcp_server.server import start_command
 
 if __name__ == "__main__":
     """Start the Jupyter MCP Server."""
-    start()
+    start_command()


### PR DESCRIPTION
## Summary
- fix import in `__main__.py` to use `start_command`
- invoke `start_command()` so running as a module starts the server correctly

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68649dc12bec8328b741ad1d70c91565