### PR TITLE
Fix connect logging format

### DIFF
--- a/jupyter_mcp_server/server.py
+++ b/jupyter_mcp_server/server.py
@@ -88,7 +88,7 @@ async def connect(request: Request):
     """Connect to a room and a runtime from the Jupyter MCP server."""
 
     data = await request.json()
-    logger.info("Connecting to room_runtime:", data)
+    logger.info("Connecting to room_runtime: %s", data)
 
     room_runtime = RoomRuntime(**data)
 


### PR DESCRIPTION
## Summary
- use a format string in connect route logging

## Testing
- `ruff check jupyter_mcp_server/server.py` *(fails: Import block unsorted or unformatted, long lines, trailing whitespace)*

------
https://chatgpt.com/codex/tasks/task_e_68649dc1ef348328b065d624a90c5fd8