### PR TITLE
Add FastAPI and HTTPX dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,8 @@ dependencies = [
     "pydantic",
     "uvicorn",
     "click",
+    "fastapi>=0.110",
+    "httpx>=0.27",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
## Summary
- add `fastapi` and `httpx` to project dependencies

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6864ad410134832880b8ed581189a749